### PR TITLE
Fix incorrect user ID

### DIFF
--- a/chat.ts
+++ b/chat.ts
@@ -378,7 +378,10 @@ export class Chat {
         isBinary: boolean
     ) {
         if (isBinary) {
-            console.error()
+            console.error('Binary messages are not supported.')
+            // This is fine, as binary messages cannot be handled by this application.
+            // eslint-disable-next-line no-restricted-syntax
+            return
         }
         const clientAddress = this.getClientAddress(request)
         if (clientAddress != null) {


### PR DESCRIPTION
- *Potentially* closes https://github.com/enso-org/cloud-v2/issues/730
  - Cleans up lookups when a WebSocket connection closes or errors out
  - Checks the `x-forwarded-for` header for the original IP, if present

Unfortunately I'm unable to reproduce the actual error, so I can't be 100% sure this fixes the bug as expected